### PR TITLE
Remove feature `hashbrown`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -83,7 +83,7 @@ jobs:
         $ver = Get-Content -Path ".\tmaze.txt"
         git clone --branch $ver https://github.com/ur-fault/TMaze.git
         cd TMaze
-        cargo build --release -F hashbrown --no-default-features
+        cargo build --release --no-default-features
 
     - name: Copy TMaze into image
       shell: powershell


### PR DESCRIPTION
TMaze has no feature `hashbrown` anymore as it was removed in the release 1.15.2.